### PR TITLE
Hide vote choices for in-progress votes

### DIFF
--- a/dokuwiki/lib/plugins/doodle/doodle_template.php
+++ b/dokuwiki/lib/plugins/doodle/doodle_template.php
@@ -9,6 +9,7 @@
   global $ID;
 
   $template = $this->template;
+  $is_closed = $this->params['closed'];
   $c = count($template['choices']);
 ?>
 
@@ -42,18 +43,30 @@
           <?php $fullname = '<a href="//people.php.net/user.php?username=' . $fullname.'">' .$fullname. '</a>';?>
           <?php echo $userData['editLinks'].$fullname.$userData['username'] ?>
         </td>
-        <?php for ($col = 0; $col < $c; $col++) {
-            echo $userData['choice'][$col];
-        } ?>        
+        <?php
+        if ($is_closed || $INFO['userinfo']['name'] == $fullname) {
+            for ($col = 0; $col < $c; $col++) {
+                echo $userData['choice'][$col];
+            }
+        } else {
+            ?><td class="votehidden" colspan="<?php echo $c ?>">&nbsp;</td><?php
+        }
+        ?>
     </tr>
 <?php } ?>
  
     <!-- Results / sum per column -->
     <tr>
         <th class="rightalign"><b><?php echo $template['result'] ?></b></th>
-<?php for ($col = 0; $col < $c; $col++) { ?>
-        <th class="centeralign"><b><?php echo $template['count'][$col] ?></b></th>
-<?php } ?>
+        <?php
+        if ($is_closed) {
+            for ($col = 0; $col < $c; $col++) {
+                ?><th class="centeralign"><b><?php echo $template['count'][$col] ?></b></th><?php
+            }
+        } else {
+            ?><th class="centeralign" colspan="<?php echo $c ?>"><?php echo count($template['doodleData']) ?></th><?php
+        }
+        ?>
     </tr>
 
 <?php

--- a/dokuwiki/lib/plugins/doodle/style.css
+++ b/dokuwiki/lib/plugins/doodle/style.css
@@ -27,3 +27,8 @@ div.dokuwiki table.inline td.notokay {
   border: 0;
   color: rgba(0, 0, 0, 0);
 }
+
+div.dokuwiki table.inline td.votehidden {
+  background-color: #f3f3f3;
+  text-align: center;
+}

--- a/systems/doodle-hide-votes-in-progress.diff
+++ b/systems/doodle-hide-votes-in-progress.diff
@@ -1,0 +1,62 @@
+diff --git a/dokuwiki/lib/plugins/doodle/doodle_template.php b/dokuwiki/lib/plugins/doodle/doodle_template.php
+index 0dafba4..843a7cd 100755
+--- a/dokuwiki/lib/plugins/doodle/doodle_template.php
++++ b/dokuwiki/lib/plugins/doodle/doodle_template.php
+@@ -9,6 +9,7 @@
+   global $ID;
+ 
+   $template = $this->template;
++  $is_closed = $this->params['closed'];
+   $c = count($template['choices']);
+ ?>
+ 
+@@ -42,18 +43,30 @@
+           <?php $fullname = '<a href="//people.php.net/user.php?username=' . $fullname.'">' .$fullname. '</a>';?>
+           <?php echo $userData['editLinks'].$fullname.$userData['username'] ?>
+         </td>
+-        <?php for ($col = 0; $col < $c; $col++) {
+-            echo $userData['choice'][$col];
+-        } ?>        
++        <?php
++        if ($is_closed || $INFO['userinfo']['name'] == $fullname) {
++            for ($col = 0; $col < $c; $col++) {
++                echo $userData['choice'][$col];
++            }
++        } else {
++            ?><td class="votehidden" colspan="<?php echo $c ?>">&nbsp;</td><?php
++        }
++        ?>
+     </tr>
+ <?php } ?>
+  
+     <!-- Results / sum per column -->
+     <tr>
+         <th class="rightalign"><b><?php echo $template['result'] ?></b></th>
+-<?php for ($col = 0; $col < $c; $col++) { ?>
+-        <th class="centeralign"><b><?php echo $template['count'][$col] ?></b></th>
+-<?php } ?>
++        <?php
++        if ($is_closed) {
++            for ($col = 0; $col < $c; $col++) {
++                ?><th class="centeralign"><b><?php echo $template['count'][$col] ?></b></th><?php
++            }
++        } else {
++            ?><th class="centeralign" colspan="<?php echo $c ?>"><?php echo count($template['doodleData']) ?></th><?php
++        }
++        ?>
+     </tr>
+ 
+ <?php
+diff --git a/dokuwiki/lib/plugins/doodle/style.css b/dokuwiki/lib/plugins/doodle/style.css
+index 0db25ee..661dfbc 100644
+--- a/dokuwiki/lib/plugins/doodle/style.css
++++ b/dokuwiki/lib/plugins/doodle/style.css
+@@ -27,3 +27,8 @@ div.dokuwiki table.inline td.notokay {
+   border: 0;
+   color: rgba(0, 0, 0, 0);
+ }
++
++div.dokuwiki table.inline td.votehidden {
++  background-color: #f3f3f3;
++  text-align: center;
++}


### PR DESCRIPTION
```
<@ekneuss> can't we hide votes until voting phase is over ?
<@salathe> I don't see why not
<@Felipe>  just have to patch the voting module :p
```

This PR implements the suggestion above, to hide the choices that people made while a vote is in progress.  A voter can see their own choice, but no-one else's.  

After voting closes, the normal behaviour is resumed; showing all votes.

![Poll with votes hidden](http://i.imgur.com/T3Dx5.png)
