### PR TITLE
clarified spam-prevention question on registration page

### DIFF
--- a/dokuwiki/inc/html.php
+++ b/dokuwiki/inc/html.php
@@ -1591,7 +1591,7 @@ function html_register(){
     }
     $form->addElement(form_makeTextField('fullname', $INPUT->post->str('fullname'), $lang['fullname'], '', 'block', $base_attrs));
     $form->addElement(form_makeField('email','email', $INPUT->post->str('email'), $lang['email'], '', 'block', $email_attrs));
-    $form->addElement(form_makeTextField('spam', $_POST['spam'], "Which email address do you have to mail now?", '', 'block', array('size'=>'50')));
+    $form->addElement(form_makeTextField('spam', $_POST['spam'], 'To which email address do you have to send an email now?', '', 'block', array('size'=>'50')));
     $form->addElement(form_makeButton('submit', '', $lang['btn_register']));
     $form->endFieldset();
     html_form('register', $form);


### PR DESCRIPTION
The wording of the spam-prevention question on the registration page seems to be misleading. Currently it is:

> Which email address do you have to mail now? 

Apparently, that is misunderstood as something like "Which email address do you have for mail now?", as examplified by many support requests on webmaster@ and internals@.