### PR TITLE
updated include plugin to latest master

### DIFF
--- a/dokuwiki/lib/plugins/include/README
+++ b/dokuwiki/lib/plugins/include/README
@@ -7,5 +7,5 @@ All documentation for the Include Plugin is available online at:
 (c) 2005 - 2007 by Esther Brunner <wikidesign@gmail.com> and Christopher 
 Smith <chris@jalakai.co.uk>
 (c) 2008 - 2009 by Gina Häußge, Michael Klier <dokuwiki@chimeric.de>
-(c) 2010 - 2011 by Michael Hamann <plugin-include@content-space.de>, Gina Häußge and Michael Klier <dokuwiki@chimeric.de>
+(c) 2010 - 2012 by Michael Hamann <michael@content-space.de>, Gina Häußge and Michael Klier <dokuwiki@chimeric.de>
 See COPYING for license info.

--- a/dokuwiki/lib/plugins/include/_test/include.group.php
+++ b/dokuwiki/lib/plugins/include/_test/include.group.php
@@ -1,9 +1,0 @@
-<?php
-require_once(DOKU_INC.'_test/lib/unittest.php');
-class include_plugin_group_test extends Doku_GroupTest {
-    function __construct() {
-        parent::__construct('include_grouptest');
-        $dir = realpath(dirname(__FILE__)).'/';
-        $this->addTestFile($dir . 'nested_include.test.php');
-    }
-}

--- a/dokuwiki/lib/plugins/include/_test/locallink_conversion.test.php
+++ b/dokuwiki/lib/plugins/include/_test/locallink_conversion.test.php
@@ -1,0 +1,38 @@
+<?php
+
+if (!defined('DOKU_INC')) die();
+
+/**
+ * Test the conversion of local links to internal links if the page hasn't been fully included
+ */
+class plugin_include_locallink_conversion_test extends DokuWikiTest {
+    /** @var helper_plugin_include $helper */
+    private $helper;
+
+    public function setUp() {
+        $this->pluginsEnabled[] = 'include';
+        parent::setUp();
+
+        $this->helper = plugin_load('helper', 'include');
+
+        saveWikiText('included', 'Example content with link [[#jump]]', 'Test setup');
+        idx_addPage('test:included');
+
+        saveWikiText('test:includefull', '{{page>..:included}}', 'Test setup');
+        idx_addPage('test:includefull');
+
+        saveWikiText('test:includefirst', '{{page>..:included&firstseconly}}', 'Test setup');
+        idx_addPage('test:includefirst');
+    }
+
+    public function testLocalConverted() {
+        $html = p_wiki_xhtml('test:includefirst');
+        $this->assertContains('href="'.wl('included').'#jump"', $html);
+        $this->assertNotContains('href="#jump"', $html);
+    }
+
+    public function testLocalExistsIfIncluded() {
+        $html = p_wiki_xhtml('test:includefull');
+        $this->assertContains('href="#jump"', $html);
+    }
+}

--- a/dokuwiki/lib/plugins/include/_test/media_linktitle_conversion.test.php
+++ b/dokuwiki/lib/plugins/include/_test/media_linktitle_conversion.test.php
@@ -1,0 +1,50 @@
+<?php
+
+if (!defined('DOKU_INC')) die();
+
+/**
+ * Test the conversion of media references in link titles
+ */
+class plugin_include_media_linktitle_conversion_test extends DokuWikiTest {
+    /** @var helper_plugin_include $helper */
+    private $helper;
+
+    public function setUp() {
+        $this->pluginsEnabled[] = 'include';
+        parent::setUp();
+
+        $this->helper = plugin_load('helper', 'include');
+
+        saveWikiText('wiki:included', <<<EOF
+  * [[test|{{dokuwiki.png}}]]
+  * [[#test|{{dokuwiki.png?w=200}}]]
+  * [[doku>test|{{dokuwiki.png?w=300}}]]
+  * [[test|{{https://www.dokuwiki.org/lib/tpl/dokuwiki/images/logo.png}}]]
+EOF
+            , 'Test setup');
+        idx_addPage('wiki:included');
+
+        saveWikiText('test:include', '{{page>..:wiki:included}}', 'Test setup');
+        idx_addPage('test:include');
+    }
+
+    public function testInternalLinkTitleConversion() {
+        $html = p_wiki_xhtml('test:include');
+        $this->assertContains('src="'.ml('wiki:dokuwiki.png').'"', $html);
+    }
+
+    public function testLocalLinkTitleConversion() {
+        $html = p_wiki_xhtml('test:include');
+        $this->assertContains('src="'.ml('wiki:dokuwiki.png', array('w' => '200')).'"', $html);
+    }
+
+    public function testInterWikiLinkTitleConversion() {
+        $html = p_wiki_xhtml('test:include');
+        $this->assertContains('src="'.ml('wiki:dokuwiki.png', array('w' => '300')).'"', $html);
+    }
+
+    public function testExternalMediaNotConverted() {
+        $html = p_wiki_xhtml('test:include');
+        $this->assertContains('src="'.ml('https://www.dokuwiki.org/lib/tpl/dokuwiki/images/logo.png').'"', $html);
+    }
+}

--- a/dokuwiki/lib/plugins/include/_test/namespace_includes.test.php
+++ b/dokuwiki/lib/plugins/include/_test/namespace_includes.test.php
@@ -1,0 +1,140 @@
+<?php
+
+if (!defined('DOKU_INC')) die();
+
+/**
+ * Test namespace includes
+ */
+class plugin_include_namespaces_includes_test extends DokuWikiTest {
+    /**
+     * @var helper_plugin_include $helper
+     */
+    private $helper;
+
+    /**
+     * Setup - enable and load the include plugin and create the test pages
+     */
+    public function setup() {
+        $this->pluginsEnabled[] = 'include';
+        parent::setup(); // this enables the include plugin
+        $this->helper = plugin_load('helper', 'include');
+
+        global $conf;
+        $conf['hidepages'] = 'inclhidden:hidden';
+
+        // for testing hidden pages
+        saveWikiText('inclhidden:hidden', 'Hidden page', 'Created hidden page');
+        saveWikiText('inclhidden:visible', 'Visible page', 'Created visible page');
+
+        // pages on different levels
+        saveWikiText('incltest:level1', 'Page on level 1', 'Created page on level 1');
+        saveWikiText('incltest:ns:level2', 'Page on level 2', 'Created page on level 2');
+        saveWikiText('incltest:ns:ns:level3', 'Page on level 3', 'Created page on level 3');
+
+        // for page ordering
+        saveWikiText('inclorder:page1', 'Page 1', 'Created page 1');
+        saveWikiText('inclorder:page2', 'Page 2', 'Created page 2');
+        saveWikiText('inclorder:page3', '{{include_n>10}} Page 3/10', 'created page 3/1');
+        saveWikiText('inclorder:page4', '{{include_n>2}} Page 4/2', 'created page 4/0');
+    }
+
+    /**
+     * Test hiding of hidden pages in namespace includes
+     */
+    public function test_hidden() {
+        $flags = $this->helper->get_flags(array());
+        $pages = $this->helper->_get_included_pages('namespace', 'inclhidden:', '', '', $flags);
+        $this->assertEquals(array(
+                                 array('id' => 'inclhidden:visible', 'exists' => true, 'parent_id' => ''),
+                            ), $pages);
+    }
+
+    /**
+     * Test include depth limit
+     */
+    public function test_depth() {
+        $flags = $this->helper->get_flags(array());
+        $pages = $this->helper->_get_included_pages('namespace', 'incltest:', '', '', $flags);
+        $this->assertEquals(array(
+                                 array('id' => 'incltest:level1', 'exists' => true, 'parent_id' => ''),
+                            ), $pages);
+        $flags = $this->helper->get_flags(array('depth=2'));
+        $pages = $this->helper->_get_included_pages('namespace', 'incltest:', '', '', $flags);
+        $this->assertEquals(array(
+                                 array('id' => 'incltest:level1', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'incltest:ns:level2', 'exists' => true, 'parent_id' => ''),
+                            ), $pages);
+        $flags = $this->helper->get_flags(array('depth=2'));
+        $pages = $this->helper->_get_included_pages('namespace', 'incltest:ns', '', '', $flags);
+        $this->assertEquals(array(
+                                 array('id' => 'incltest:ns:level2', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'incltest:ns:ns:level3', 'exists' => true, 'parent_id' => ''),
+                            ), $pages);
+        $flags = $this->helper->get_flags(array('depth=0'));
+        $pages = $this->helper->_get_included_pages('namespace', 'incltest:', '', '', $flags);
+        $this->assertEquals(array(
+                                 array('id' => 'incltest:level1', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'incltest:ns:level2', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'incltest:ns:ns:level3', 'exists' => true, 'parent_id' => ''),
+                            ), $pages);
+
+        // test include of the root namespace
+        $flags = $this->helper->get_flags(array());
+        $pages = $this->helper->_get_included_pages('namespace', ':', '', '', $flags);
+        $this->assertEquals(array(), $pages);
+        $flags = $this->helper->get_flags(array('depth=2'));
+        $pages = $this->helper->_get_included_pages('namespace', ':', '', '', $flags);
+        $this->assertEquals(array(
+                                 array('id' => 'inclhidden:visible', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page1', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page2', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page3', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page4', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'incltest:level1', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'wiki:dokuwiki', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'wiki:syntax', 'exists' => true, 'parent_id' => ''),
+                            ), $pages);
+    }
+
+    /**
+     * Test ordering of namespace includes
+     */
+    public function test_order() {
+
+        $flags = $this->helper->get_flags(array());
+        $pages = $this->helper->_get_included_pages('namespace', 'inclorder:', '', '', $flags);
+
+        $this->assertEquals(array(
+                                 array('id' => 'inclorder:page1', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page2', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page3', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page4', 'exists' => true, 'parent_id' => ''),
+                            ), $pages);
+
+        $flags = $this->helper->get_flags(array('rsort'));
+        $pages = $this->helper->_get_included_pages('namespace', 'inclorder:', '', '', $flags);
+        $this->assertEquals(array(
+                                 array('id' => 'inclorder:page4', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page3', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page2', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page1', 'exists' => true, 'parent_id' => ''),
+                            ), $pages);
+        $flags = $this->helper->get_flags(array('order=custom'));
+        $pages = $this->helper->_get_included_pages('namespace', 'inclorder:', '', '', $flags);
+        $this->assertEquals(array(
+                                 array('id' => 'inclorder:page4', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page3', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page1', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page2', 'exists' => true, 'parent_id' => ''),
+                            ), $pages);
+
+        $flags = $this->helper->get_flags(array('order=custom', 'rsort'));
+        $pages = $this->helper->_get_included_pages('namespace', 'inclorder:', '', '', $flags);
+        $this->assertEquals(array(
+                                 array('id' => 'inclorder:page2', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page1', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page3', 'exists' => true, 'parent_id' => ''),
+                                 array('id' => 'inclorder:page4', 'exists' => true, 'parent_id' => ''),
+                            ), $pages);
+    }
+}

--- a/dokuwiki/lib/plugins/include/_test/nested_include.test.php
+++ b/dokuwiki/lib/plugins/include/_test/nested_include.test.php
@@ -1,46 +1,27 @@
 <?php
-require_once(DOKU_INC.'_test/lib/unittest.php');
-require_once(DOKU_INC.'inc/init.php');
-class plugin_include_nested_test extends Doku_UnitTestCase {
+
+class plugin_include_nested_test extends DokuWikiTest {
     private $ids = array(
         'test:plugin_include:nested:start',
         'test:plugin_include:nested:second',
         'test:plugin_include:nested:third'
     );
 
-    public function tearDown() {
-        foreach($this->ids as $id) {
-            saveWikiText($id,'','deleted in tearDown()');
-            @unlink(metaFN($id, '.meta'));
-        }
+    public function setup() {
+        $this->pluginsEnabled[] = 'include';
+        parent::setup();
     }
 
-    public function setUp() {
-        saveWikiText('test:plugin_include:nested:start', 
-            '====== Main Test Page ======'.DOKU_LF.DOKU_LF
-            .'Main Content'.DOKU_LF.DOKU_LF
-            .'{{page>second}}'.DOKU_LF,
-            'setup for test');
-        saveWikiText('test:plugin_include:nested:second', 
-            '====== Second Test Page ======'.DOKU_LF.DOKU_LF
-            .'Second Content'.DOKU_LF.DOKU_LF
-            .'{{page>third}}'.DOKU_LF,
-            'setup for test');
-        saveWikiText('test:plugin_include:nested:third', 
-            '====== Third Test Page ======'.DOKU_LF.DOKU_LF
-            .'Third Content'.DOKU_LF.DOKU_LF
-            .'{{page>third}}'.DOKU_LF,
-            'setup for test');
-    }
-
-    public function testOuterToInner() {
+    public function test_outer_to_inner() {
+        $this->_createPages();
         $mainHTML = p_wiki_xhtml('test:plugin_include:nested:start');
         $secondHTML = p_wiki_xhtml('test:plugin_include:nested:second');
         $thirdHTML = p_wiki_xhtml('test:plugin_include:nested:third');
         $this->_validateContent($mainHTML, $secondHTML, $thirdHTML);
     }
 
-    public function testInnerToOuter() {
+    public function test_inner_to_outer() {
+        $this->_createPages();
         $thirdHTML = p_wiki_xhtml('test:plugin_include:nested:third');
         $secondHTML = p_wiki_xhtml('test:plugin_include:nested:second');
         $mainHTML = p_wiki_xhtml('test:plugin_include:nested:start');
@@ -63,7 +44,25 @@ class plugin_include_nested_test extends Doku_UnitTestCase {
     }
 
     private function _matchHeader($level, $text, $html) {
-        return preg_match('/<h'.$level.'[^>]*><a[^>]*>'.$text.'/', $html) > 0;
+        return preg_match('/<h'.$level.'[^>]*>(<a[^>]*>)?'.$text.'/', $html) > 0;
+    }
+
+    private function _createPages() {
+        saveWikiText('test:plugin_include:nested:start', 
+            '====== Main Test Page ======'.DOKU_LF.DOKU_LF
+            .'Main Content'.rand().DOKU_LF.DOKU_LF
+            .'{{page>second}}'.DOKU_LF,
+            'setup for test');
+        saveWikiText('test:plugin_include:nested:second', 
+            '====== Second Test Page ======'.DOKU_LF.DOKU_LF
+            .'Second Content'.rand().DOKU_LF.DOKU_LF
+            .'{{page>third}}'.DOKU_LF,
+            'setup for test');
+        saveWikiText('test:plugin_include:nested:third', 
+            '====== Third Test Page ======'.DOKU_LF.DOKU_LF
+            .'Third Content'.rand().DOKU_LF.DOKU_LF
+            .'{{page>third}}'.DOKU_LF,
+            'setup for test');
     }
 }
 

--- a/dokuwiki/lib/plugins/include/_test/pagemove_support.test.php
+++ b/dokuwiki/lib/plugins/include/_test/pagemove_support.test.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Tests the editx support for adapting the syntax of the include plugin
+ */
+class plugin_include_pagemove_support_test extends DokuWikiTest {
+    public function setup() {
+        $this->pluginsEnabled[] = 'move';
+        $this->pluginsEnabled[] = 'include';
+        parent::setup();
+    }
+
+    public function test_relative_include() {
+        global $ID;
+        /** @var $move helper_plugin_move */
+        $move = plugin_load('helper', 'move');
+        if (!$move) return; // disable the test when move is not installed
+        saveWikiText('editx', '{{page>start#start}} %%{{page>start}}%% {{section>wiki:syntax#tables&nofooter}} {{page>:}} {{section>test:start#test}}', 'Testcase created');
+        idx_addPage('editx');
+        $ID = 'editx';
+        $opts['ns']      = '';
+        $opts['newname'] = 'editx';
+        $opts['newns']   = 'test';
+        $move->move_page($opts);
+        $this->assertEquals('{{page>:start#start}} %%{{page>start}}%% {{section>wiki:syntax#tables&nofooter}} {{page>:}} {{section>test:start#test}}',rawWiki('test:editx'));
+    }
+
+    public function test_rename() {
+        global $ID;
+        /** @var $move helper_plugin_move */
+        $move = plugin_load('helper', 'move');
+        if (!$move) return; // disable the test when move is not installed
+        saveWikiText('editx', 'Page to rename', 'Testcase create');
+        saveWikiText('links', '{{section>links#foo}} {{page>editx}} {{page>:eDitX&nofooter}} {{section>editx#test}} {{page>editx&nofooter}}', 'Testcase created');
+        idx_addPage('editx');
+        idx_addPage('links');
+
+        $ID = 'editx';
+        $opts['ns']      = '';
+        $opts['newname'] = 'edit';
+        $opts['newns']   = 'test';
+        $move->move_page($opts);
+        $this->assertEquals('{{section>links#foo}} {{page>test:edit}} {{page>test:edit&nofooter}} {{section>test:edit#test}} {{page>test:edit&nofooter}}', rawWiki('links'));
+    }
+}

--- a/dokuwiki/lib/plugins/include/_test/safeindex.test.php
+++ b/dokuwiki/lib/plugins/include/_test/safeindex.test.php
@@ -1,0 +1,36 @@
+<?php
+
+class plugin_include_safeindex_test extends DokuWikiTest {
+    public function setup() {
+        $this->pluginsEnabled[] = 'include';
+        parent::setup();
+    }
+
+    public function test_safeindex() {
+        global $conf;
+        global $AUTH_ACL;
+        $conf['superuser'] = 'john';
+        $conf['useacl']    = 1;
+
+        $AUTH_ACL = array(
+            '*           @ALL           0',
+            '*           @user          8',
+            'public      @ALL           1',
+        );
+
+        $_SERVER['REMOTE_USER'] = 'john';
+
+        saveWikiText('parent', "{{page>child}}\n\n[[public_link]]\n\n{{page>public}}", 'Test parent created');
+        saveWikiText('child', "[[foo:private]]", 'Test child created');
+        saveWikiText('public', "[[foo:public]]", 'Public page created');
+
+        idx_addPage('parent');
+        idx_addPage('child');
+        idx_addPage('public');
+
+        $this->assertEquals(array('parent', 'public'), ft_backlinks('foo:public'));
+        $this->assertEquals(array('child'), ft_backlinks('foo:private'));
+        $this->assertEquals(array('parent'), ft_backlinks('public_link'));
+    }
+}
+

--- a/dokuwiki/lib/plugins/include/action.php
+++ b/dokuwiki/lib/plugins/include/action.php
@@ -19,7 +19,7 @@ require_once(DOKU_PLUGIN.'action.php');
  */
 class action_plugin_include extends DokuWiki_Action_Plugin {
  
-    var $supportedModes = array('xhtml', 'metadata');
+    /* @var helper_plugin_include $helper */
     var $helper = null;
 
     function action_plugin_include() {
@@ -29,7 +29,10 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     /**
      * plugin should use this method to register its handlers with the dokuwiki's event controller
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
+        /* @var Doku_event_handler $controller */
+        $controller->register_hook('INDEXER_PAGE_ADD', 'BEFORE', $this, 'handle_indexer');
+        $controller->register_hook('INDEXER_VERSION_GET', 'BEFORE', $this, 'handle_indexer_version');
       $controller->register_hook('PARSER_CACHE_USE','BEFORE', $this, '_cache_prepare');
       $controller->register_hook('HTML_EDITFORM_OUTPUT', 'BEFORE', $this, 'handle_form');
       $controller->register_hook('HTML_CONFLICTFORM_OUTPUT', 'BEFORE', $this, 'handle_form');
@@ -38,6 +41,89 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
       $controller->register_hook('PARSER_HANDLER_DONE', 'BEFORE', $this, 'handle_parser');
       $controller->register_hook('PARSER_METADATA_RENDER', 'AFTER', $this, 'handle_metadata');
       $controller->register_hook('HTML_SECEDIT_BUTTON', 'BEFORE', $this, 'handle_secedit_button');
+        $controller->register_hook('PLUGIN_MOVE_HANDLERS_REGISTER', 'BEFORE', $this, 'handle_move_register');
+    }
+
+    /**
+     * Add a version string to the index so it is rebuilt
+     * whenever the handler is updated or the safeindex setting is changed
+     */
+    public function handle_indexer_version($event, $param) {
+        $event->data['plugin_include'] = '0.1.safeindex='.$this->getConf('safeindex');
+    }
+
+    /**
+     * Handles the INDEXER_PAGE_ADD event, prevents indexing of metadata from included pages that aren't public if enabled
+     *
+     * @param Doku_Event $event  the event object
+     * @param array      $params optional parameters (unused)
+     */
+    public function handle_indexer(Doku_Event $event, $params) {
+        global $USERINFO;
+
+        // check if the feature is enabled at all
+        if (!$this->getConf('safeindex')) return;
+
+        // is there a user logged in at all? If not everything is fine already
+        if (is_null($USERINFO) && !isset($_SERVER['REMOTE_USER'])) return;
+
+        // get the include metadata in order to see which pages were included
+        $inclmeta = p_get_metadata($event->data['page'], 'plugin_include', METADATA_RENDER_UNLIMITED);
+        $all_public = true; // are all included pages public?
+        // check if the current metadata indicates that non-public pages were included
+        if ($inclmeta !== null && isset($inclmeta['pages'])) {
+            foreach ($inclmeta['pages'] as $page) {
+                if (auth_aclcheck($page['id'], '', array()) < AUTH_READ) { // is $page public?
+                    $all_public = false;
+                    break;
+                }
+            }
+        }
+
+        if (!$all_public) { // there were non-public pages included - action required!
+            // backup the user information
+            $userinfo_backup = $USERINFO;
+            $remote_user = $_SERVER['REMOTE_USER'];
+            // unset user information - temporary logoff!
+            $USERINFO = null;
+            unset($_SERVER['REMOTE_USER']);
+
+            // metadata is only rendered once for a page in one request - thus we need to render manually.
+            $meta = p_read_metadata($event->data['page']); // load the original metdata
+            $meta = p_render_metadata($event->data['page'], $meta); // render the metadata
+            p_save_metadata($event->data['page'], $meta); // save the metadata so other event handlers get the public metadata, too
+
+            $meta = $meta['current']; // we are only interested in current metadata.
+
+            // check if the tag plugin handler has already been called before the include plugin
+            $tag_called = isset($event->data['metadata']['subject']);
+
+            // Reset the metadata in the renderer. This removes data from all other event handlers, but we need to be on the safe side here.
+            $event->data['metadata'] = array('title' => $meta['title']);
+
+            // restore the relation references metadata
+            if (isset($meta['relation']['references'])) {
+                $event->data['metadata']['relation_references'] = array_keys($meta['relation']['references']);
+            } else {
+                $event->data['metadata']['relation_references'] = array();
+            }
+
+            // restore the tag metadata if the tag plugin handler has been called before the include plugin handler.
+            if ($tag_called) {
+                $tag_helper = $this->loadHelper('tag', false);
+                if ($tag_helper) {
+                    if (isset($meta['subject']))  {
+                        $event->data['metadata']['subject'] = $tag_helper->_cleanTagList($meta['subject']);
+                    } else {
+                        $event->data['metadata']['subject'] = array();
+                    }
+                }
+            }
+
+            // restore user information
+            $USERINFO = $userinfo_backup;
+            $_SERVER['REMOTE_USER'] = $remote_user;
+        }
     }
 
     /**
@@ -58,7 +144,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
      * @author Michael Klier <chi@chimeric.de>
      * @author Michael Hamann <michael@content-space.de>
      */
-    function handle_parser(&$event, $param) {
+    function handle_parser(Doku_Event $event, $param) {
         global $ID;
 
         $level = 0;
@@ -69,7 +155,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
             case 'plugin':
                 switch($ins[$i][1][0]) {
                 case 'include_include':
-                    $ins[$i][1][1][] = $level;
+                    $ins[$i][1][1][4] = $level;
                     break;
                     /* FIXME: this doesn't work anymore that way with the new structure
                     // some plugins already close open sections
@@ -90,7 +176,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     /**
      * Add a hidden input to the form to preserve the redirect_id
      */
-    function handle_form(&$event, $param) {
+    function handle_form(Doku_Event &$event, $param) {
       if (array_key_exists('redirect_id', $_REQUEST)) {
         $event->data->addHidden('redirect_id', cleanID($_REQUEST['redirect_id']));
       }
@@ -99,7 +185,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     /**
      * Modify the data for the redirect when there is a redirect_id set
      */
-    function handle_redirect(&$event, $param) {
+    function handle_redirect(Doku_Event &$event, $param) {
       if (array_key_exists('redirect_id', $_REQUEST)) {
         // Render metadata when this is an older DokuWiki version where
         // metadata is not automatically re-rendered as the page has probably
@@ -116,13 +202,14 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     /**
      * prepare the cache object for default _useCache action
      */
-    function _cache_prepare(&$event, $param) {
+    function _cache_prepare(Doku_Event &$event, $param) {
         global $conf;
 
+        /* @var cache_renderer $cache */
         $cache =& $event->data;
 
         if(!isset($cache->page)) return;
-        if(!isset($cache->mode) || !in_array($cache->mode, $this->supportedModes)) return;
+        if(!isset($cache->mode) || $cache->mode == 'i') return;
 
         $depends = p_get_metadata($cache->page, 'plugin_include');
         
@@ -169,27 +256,51 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
      * and replace normal section edit buttons when the current page is different from the
      * global $ID.
      */
-    function handle_secedit_button(&$event, $params) {
+    function handle_secedit_button(Doku_Event &$event, $params) {
         // stack of included pages in the form ('id' => page, 'rev' => modification time, 'writable' => bool)
         static $page_stack = array();
 
-        global $ID;
+        global $ID, $lang;
 
         $data = $event->data;
 
         if ($data['target'] == 'plugin_include_start' || $data['target'] == 'plugin_include_start_noredirect') {
             // handle the "section edits" added by the include plugin
             $fn = wikiFN($data['name']);
+            $perm = auth_quickaclcheck($data['name']);
             array_unshift($page_stack, array(
                 'id' => $data['name'],
                 'rev' => @filemtime($fn),
-                'writable' => (is_writable($fn) && auth_quickaclcheck($data['name']) >= AUTH_EDIT),
+                'writable' => (page_exists($data['name']) ? (is_writable($fn) && $perm >= AUTH_EDIT) : $perm >= AUTH_CREATE),
                 'redirect' => ($data['target'] == 'plugin_include_start'),
             ));
         } elseif ($data['target'] == 'plugin_include_end') {
             array_shift($page_stack);
-        } elseif (!empty($page_stack)) {
+        } elseif ($data['target'] == 'plugin_include_editbtn') {
             if ($page_stack[0]['writable']) {
+                $params = array('do' => 'edit',
+                    'id' => $page_stack[0]['id']);
+                if ($page_stack[0]['redirect'])
+                    $params['redirect_id'] = $ID;
+                $event->result = '<div class="secedit">' . DOKU_LF .
+                    html_btn('incledit', $page_stack[0]['id'], '',
+                        $params, 'post',
+                        $data['name'],
+                        $lang['btn_secedit'].' ('.$page_stack[0]['id'].')') .
+                    '</div>' . DOKU_LF;
+            }
+        } elseif (!empty($page_stack)) {
+
+            // Special handling for the edittable plugin
+            if ($data['target'] == 'table' && !plugin_isdisabled('edittable')) {
+                /* @var action_plugin_edittable_editor $edittable */
+                $edittable =& plugin_load('action', 'edittable_editor');
+                if (is_null($edittable))
+                    $edittable =& plugin_load('action', 'edittable');
+                $data['name'] = $edittable->getLang('secedit_name');
+            }
+
+            if ($page_stack[0]['writable'] && isset($data['name']) && $data['name'] !== '') {
                 $name = $data['name'];
                 unset($data['name']);
 
@@ -215,6 +326,31 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
 
         $event->preventDefault();
         $event->stopPropagation();
+    }
+
+    public function handle_move_register(Doku_Event $event, $params) {
+        $event->data['handlers']['include_include'] = array($this, 'rewrite_include');
+    }
+
+    public function rewrite_include($match, $pos, $state, $plugin, helper_plugin_move_handler $handler) {
+        $syntax = substr($match, 2, -2); // strip markup
+        $replacers = explode('|', $syntax);
+        $syntax = array_shift($replacers);
+        list($syntax, $flags) = explode('&', $syntax, 2);
+
+        // break the pattern up into its parts
+        list($mode, $page, $sect) = preg_split('/>|#/u', $syntax, 3);
+        $newpage = $handler->adaptRelativeId($page);
+        if ($newpage == $page) {
+            return $match;
+        } else {
+            $result = '{{'.$mode.'>'.$newpage;
+            if ($sect) $result .= '#'.$sect;
+            if ($flags) $result .= '&'.$flags;
+            if ($replacers) $result .= '|'.$replacers;
+            $result .= '}}';
+            return $result;
+        }
     }
 }
 // vim:ts=4:sw=4:et:

--- a/dokuwiki/lib/plugins/include/conf/default.php
+++ b/dokuwiki/lib/plugins/include/conf/default.php
@@ -2,12 +2,14 @@
 /**
  * Options for the Include Plugin
  */
+$conf['noheader']      = 0;      // Don't display the header of the inserted section
 $conf['firstseconly']  = 0;      // limit entries on main blog page to first section
 $conf['showtaglogos']  = 0;      // display image for first tag
 $conf['showfooter']    = 1;      // display meta line below blog entries
 $conf['showlink']      = 0;      // link headlines of blog entries
 $conf['showpermalink'] = 0;      // show permalink below blog entries
 $conf['showdate']      = 1;      // show date below blog entries
+$conf['showmdate']     = 0;      // show modification date below blog entries
 $conf['showuser']      = 1;      // show username below blog entries
 $conf['showcomments']  = 1;      // show number of comments below blog entries
 $conf['showlinkbacks'] = 1;      // show number of linkbacks below blog entries
@@ -17,5 +19,12 @@ $conf['doredirect']    = 1;      // redirect back to original page after an edit
 $conf['usernamespace'] = 'user'; // namespace for user pages
 $conf['doindent']      = 1;      // indent included pages relative to the page they get included
 $conf['linkonly']      = 0;      // link only to the included pages instead of including the content
-
+$conf['title']        = 0;       // use first header of page in link
+$conf['pageexists']   = 0;       // no link if page does not exist
+$conf['parlink']      = 1;       // paragraph around link
+$conf['safeindex']    = 1;       // prevent indexing of protected metadata
+$conf['order']        = 'id';    // order in which the pages are included in the case of multiple pages
+$conf['rsort']        = 0;       // reverse sort order
+$conf['depth']        = 1;       // maximum depth of namespace includes, 0 for unlimited depth
+$conf['readmore']     = 1;       // Show readmore link in case of firstsection only
 //Setup VIM: ex: et ts=2 :

--- a/dokuwiki/lib/plugins/include/conf/metadata.php
+++ b/dokuwiki/lib/plugins/include/conf/metadata.php
@@ -5,12 +5,14 @@
  *
  * @author    Esther Brunner <wikidesign@gmail.com>
  */
+$meta['noheader']      = array('onoff');
 $meta['firstseconly']  = array('onoff');
 $meta['showtaglogos']  = array('onoff');
-$meta['showfooter']    = array('onoff');
 $meta['showlink']      = array('onoff');
+$meta['showfooter']    = array('onoff');
 $meta['showpermalink'] = array('onoff');
 $meta['showdate']      = array('onoff');
+$meta['showmdate']     = array('onoff');
 $meta['showuser']      = array('onoff');
 $meta['showcomments']  = array('onoff');
 $meta['showlinkbacks'] = array('onoff');
@@ -20,5 +22,12 @@ $meta['doredirect']    = array('onoff');
 $meta['usernamespace'] = array('string');
 $meta['doindent']      = array('onoff');
 $meta['linkonly']      = array('onoff');
-
+$meta['title']         = array('onoff');
+$meta['pageexists']    = array('onoff');
+$meta['parlink']       = array('onoff');
+$meta['safeindex']     = array('onoff');
+$meta['order']         = array('multichoice', '_choices' => array('id', 'title', 'created', 'modified', 'indexmenu', 'custom'));
+$meta['rsort']         = array('onoff');
+$meta['depth']         = array('numeric', '_min' => 0);
+$meta['readmore']      = array('onoff');
 //Setup VIM: ex: et ts=2 :

--- a/dokuwiki/lib/plugins/include/lang/da/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/da/lang.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author Soren Birk <soer9648@eucl.dk>
+ */
+$lang['readmore']              = '→ Læs mere...';

--- a/dokuwiki/lib/plugins/include/lang/da/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/da/settings.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author Soren Birk <soer9648@eucl.dk>
+ */
+$lang['noheader']              = 'Vis ikke den første header for inkluderede sider/sektioner';
+$lang['firstseconly']          = 'vis kun den første sektion for inkluderede sider';
+$lang['showtaglogos']          = 'vis billede for første tag';
+$lang['showfooter']            = 'vis info på inkluderet side nedenfor';
+$lang['showlink']              = 'link første overskrift af inkluderet side';
+$lang['showpermalink']         = 'vis permalinks nedenfor inkluderet side';
+$lang['showdate']              = 'vis datoer nedenfor inkluderet side';
+$lang['showmdate']             = 'vis redigeret datoer nedenfor inkluderet side';
+$lang['showuser']              = 'vis brugernavne nedenfor inkluderet side';
+$lang['showcomments']          = 'vis kommentarer nedenfor inkluderet side (Discussion plugin nødvendigt)';
+$lang['showlinkbacks']         = 'vis linkbacks nedenfor inkluderet side (Linkback Plugin nødvendigt)';
+$lang['showtags']              = 'vis tags nedenfor inkluderet side (Tag Plugin nødvendigt)';
+$lang['showeditbtn']           = 'vis redigér-knap';
+$lang['doredirect']            = 'henvis til original side efter redigering af den inkluderede side';
+$lang['usernamespace']         = 'navnerum for brugersider';
+$lang['doindent']              = 'indryk inkluderede sider relativt i forhold til siden de inkluderes i';
+$lang['linkonly']              = 'link udelukkende til den inkluderede side i stedet for at vise indholdet';
+$lang['title']                 = 'benyt sidens første overskrift i link, selvom useheading er slået fra (har kun effekt på linkonly-tilstand)';
+$lang['pageexists']            = 'Vis ikke et link hvis siden ikke findes (har kun effekt på linkonly-tilstand)';
+$lang['parlink']               = 'omkreds linket i et afsnit (har kun effekt på linkonly-tilstand)';
+$lang['safeindex']             = 'undgå indeksering af metadata fra ikke-offentlige inkluderede sider';
+$lang['order']                 = 'kriterier til rækkefølge for inkluderede med adskellige sider';
+$lang['order_o_id']            = 'side-ID';
+$lang['order_o_title']         = 'titel';
+$lang['order_o_created']       = 'oprettelsesdato';
+$lang['order_o_modified']      = 'dato for modifikation';
+$lang['order_o_indexmenu']     = 'brugerdefineret orden med indexmenu-syntaks';
+$lang['order_o_custom']        = 'brugerdefineret orden med inkludér-syntaks';
+$lang['rsort']                 = 'vend rækkefølgen for sortering af inkluderede sider';
+$lang['depth']                 = 'maksimum dybde af inkluderede navnerum, 0 for uendelig dybde';

--- a/dokuwiki/lib/plugins/include/lang/de-informal/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/de-informal/lang.php
@@ -1,8 +1,10 @@
 <?php
-
 /**
+ * German language file
+ *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * 
  * @author     Esther Brunner <wikidesign@gmail.com>
  */
-$lang['readmore']              = '→ Weiterlesen...';
+
+// custom language strings for the plugin
+$lang['readmore']   = '→ Weiter lesen...';

--- a/dokuwiki/lib/plugins/include/lang/de-informal/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/de-informal/settings.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * German language file
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Esther Brunner <wikidesign@gmail.com>
+ */
+
+// for the configuration manager
+$lang['noheader']      = 'Zeige nicht den ersten Header von eingeschlossenen Seiten/Sektionen';
+$lang['firstseconly']  = 'Nur erster Abschnitt von eingebundenen Seiten';
+$lang['showtaglogos']  = 'Bild für erstes Tag anzeigen';
+$lang['showfooter']    = 'Infos über eingebundene Seite darunter anzeigen';
+$lang['showlink']      = 'Erste Überschrift der eingebundenen Seite als Link anzeigen';
+$lang['showpermalink'] = 'Permalink unter eingebunderer Seite anzeigen';
+$lang['showdate']      = 'Datum unter eingebundender Seite anzeigen';
+$lang['showmdate']     = 'Datum der Bearbeitung unter eingebundender Seite anzeigen';
+$lang['showuser']      = 'Autorenname unter eingebunderer Seite anzeigen';
+$lang['showcomments']  = 'Kommentare unter eingebundener Seite anzeigen (Discussion Plugin wird benötigt)';
+$lang['showlinkbacks'] = 'Linkbacks unter eingebundener Seite anzeigen (Linkback Plugin wird benötigt)';
+$lang['showtags']      = 'Tags unter eingebundener Seite anzeigen (Tag Plugin wird benötigt)';
+$lang['showeditbtn']   = 'Bearbeiten-Tasten anzeigen';
+$lang['doredirect']    = 'Nach dem Bearbeiten der eingebundenen Seite zur ursprünglichen Seite weiterleiten';
+$lang['usernamespace'] = 'Namensraum für Benutzerseiten';
+$lang['doindent']      = 'Eingebundene Seiten relativ zur Seite, in der sie eingebunden sind einrücken';
+$lang['linkonly']      = 'Nur einen Link anzeigen statt dem Inhalt der eingebundenen Seite';
+$lang['title']         = 'Erste Überschrift im Link benutzen auch wenn "useheading" ausgeschaltet ist (betrifft nur den "linkonly"-Modus)';
+$lang['pageexists']    = 'Keinen Link anzeigen, wenn die verlinkte Seite nicht existiert (betrifft nur den "linkonly"-Modus)';
+$lang['parlink']       = 'Einen Absatz um den Link herum anzeigen (betrifft nur den "linkonly"-Modus)';
+$lang['safeindex']     = 'verhindern der Indizierung der Metadaten von nicht-öffentlichen Seiten';
+$lang['order']         = 'Sortierkriterium von Einschlüssen mit multiplen Seiten';
+$lang['rsort']         = 'kehre die Sortierreihenfolge von eingeschlossenen Seiten um';
+$lang['depth']         = 'maximale Tiefe von Namespace Einschlüssen, 0 für unbegrenzte Tiefe';

--- a/dokuwiki/lib/plugins/include/lang/de/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/de/settings.php
@@ -1,24 +1,38 @@
 <?php
+
 /**
- * German language file
- *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
  * @author     Esther Brunner <wikidesign@gmail.com>
+ * @author Dominik Eckelmann <deckelmann@gmail.com>
  */
-
-// for the configuration manager
-$lang['firstseconly']  = 'Nur erster Abschnitt von eingebundenen Seiten';
-$lang['showtaglogos']  = 'Bild für erstes Tag anzeigen';
-$lang['showfooter']    = 'Infos über eingebundene Seite darunter anzeigen';
-$lang['showlink']      = 'Permalink unter eingebunderer Seite anzeigen';
-$lang['showdate']      = 'Datum unter eingebunderer Seite anzeigen';
-$lang['showuser']      = 'Autorenname unter eingebunderer Seite anzeigen';
-$lang['showcomments']  = 'Kommentare unter eingebundener Seite anzeigen (Discussion Plugin wird benötigt)';
-$lang['showlinkbacks'] = 'Linkbacks unter eingebundener Seite anzeigen (Linkback Plugin wird benötigt)';
-$lang['showtags']      = 'Tags unter eingebundener Seite anzeigen (Tag Plugin wird benötigt)';
-$lang['showeditbtn']   = 'Bearbeiten-Tasten anzeigen';
-$lang['doredirect']    = 'Nach dem Bearbeiten der eingebundenen Seite zur ursprünglichen Seite weiterleiten';
-$lang['usernamespace'] = 'Namensraum für Benutzerseiten';
-$lang['linkonly']      = 'Nur einen Link anzeigen statt dem Inhalt der eingebundenen Seite';
-
-//Setup VIM: ex: et ts=2 :
+$lang['noheader']              = 'Verstecke die erste Überschrift der eingefügten Seite/Sektion';
+$lang['firstseconly']          = 'Nur erster Abschnitt von eingebundenen Seiten';
+$lang['showtaglogos']          = 'Bild für erstes Tag anzeigen';
+$lang['showfooter']            = 'Infos über eingebundene Seite darunter anzeigen';
+$lang['showlink']              = 'Erste Überschrift der eingebundenen Seite als Link anzeigen';
+$lang['showpermalink']         = 'Permalink unter eingebunderer Seite anzeigen';
+$lang['showdate']              = 'Datum unter eingebunderer Seite anzeigen';
+$lang['showmdate']             = 'Zeige das Änderungsdatum unter eingefügten Seiten an';
+$lang['showuser']              = 'Autorenname unter eingebunderer Seite anzeigen';
+$lang['showcomments']          = 'Kommentare unter eingebundener Seite anzeigen (Discussion Plugin wird benötigt)';
+$lang['showlinkbacks']         = 'Linkbacks unter eingebundener Seite anzeigen (Linkback Plugin wird benötigt)';
+$lang['showtags']              = 'Tags unter eingebundener Seite anzeigen (Tag Plugin wird benötigt)';
+$lang['showeditbtn']           = 'Bearbeiten-Tasten anzeigen';
+$lang['doredirect']            = 'Nach dem Bearbeiten der eingebundenen Seite zur ursprünglichen Seite weiterleiten';
+$lang['usernamespace']         = 'Namensraum für Benutzerseiten';
+$lang['doindent']              = 'Eingebundene Seiten relativ zur Seite, in der sie eingebunden sind einrücken';
+$lang['linkonly']              = 'Nur einen Link anzeigen statt dem Inhalt der eingebundenen Seite';
+$lang['title']                 = 'Erste Überschrift im Link benutzen auch wenn "useheading" ausgeschaltet ist (betrifft nur den "linkonly"-Modus)';
+$lang['pageexists']            = 'Keinen Link anzeigen, wenn die verlinkte Seite nicht existiert (betrifft nur den "linkonly"-Modus)';
+$lang['parlink']               = 'Einen Absatz um den Link herum anzeigen (betrifft nur den "linkonly"-Modus)';
+$lang['safeindex']             = 'Verhindere das indizieren von Metadaten auf eingebundenen, nicht öffentlichen Seiten';
+$lang['order']                 = 'Sortierkriterium beim einfügen von mehreren Seiten';
+$lang['order_o_id']            = 'Seiten ID';
+$lang['order_o_title']         = 'Titel';
+$lang['order_o_created']       = 'Erstellungsdatum';
+$lang['order_o_modified']      = 'Änderungsdatum';
+$lang['order_o_indexmenu']     = 'Benutzerdefinierte Reihenfolge mit Indexmenu Syntax.';
+$lang['order_o_custom']        = 'Benutzerdefinierte Reihenfolge mit Include Syntax';
+$lang['rsort']                 = 'Umgekehrte Reihenfolge bei der Sortierung von eingefügten Seiten';
+$lang['depth']                 = 'Maximale tiefe von Namensräumen, 0 für unendliche tiefe';

--- a/dokuwiki/lib/plugins/include/lang/en/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/en/settings.php
@@ -7,12 +7,14 @@
  */
  
 // for the configuration manager
+$lang['noheader']      = 'Don\'t show the first header of included pages/sections';
 $lang['firstseconly']  = 'show only the first section of included pages';
 $lang['showtaglogos']  = 'show image for first tag';
 $lang['showfooter']    = 'show info about included page below';
 $lang['showlink']      = 'link first headline of included page';
 $lang['showpermalink'] = 'show permalinks below included page';
 $lang['showdate']      = 'show dates below included page';
+$lang['showmdate']     = 'show modified dates below included page';
 $lang['showuser']      = 'show usernames below included page';
 $lang['showcomments']  = 'show comments below included page (Discussion plugin needed)';
 $lang['showlinkbacks'] = 'show linkbacks below included page (Linkback Plugin needed)';
@@ -22,5 +24,18 @@ $lang['doredirect']    = 'redirect to the original page after editing the includ
 $lang['usernamespace'] = 'namespace for user pages';
 $lang['doindent']      = 'indent included pages relative to the page they get included in';
 $lang['linkonly']      = 'link only to the included page instead of showing the content';
-
+$lang['title']         = 'use first heading of page in link even if useheading is off (only affects linkonly mode)';
+$lang['pageexists']    = 'do not display a link if the page does not exist (only affects linkonly mode)';
+$lang['parlink']       = 'put a paragraph around the link (only affects linkonly mode)';
+$lang['safeindex']     = 'prevent indexing of metadata from non-public included pages';
+$lang['order']         = 'ordering criteria of includes with multiple pages';
+$lang['order_o_id']    = 'page ID';
+$lang['order_o_title'] = 'title';
+$lang['order_o_created'] = 'creation date';
+$lang['order_o_modified'] = 'modification date';
+$lang['order_o_indexmenu'] = 'custom order with indexmenu syntax';
+$lang['order_o_custom'] = 'custom order with include syntax';
+$lang['rsort']         = 'reverse the sort order of the included pages';
+$lang['depth']         = 'maximum depth of namespace includes, 0 for unlimited depth';
+$lang['readmore']       = 'Show or not the \'Read More\' link in case of firstsection only';
 //Setup VIM: ex: et ts=2 :

--- a/dokuwiki/lib/plugins/include/lang/eo/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/eo/lang.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author Robert Bogenschneider <bogi@uea.org>
+ */
+$lang['readmore']              = '→ Legi plu...';

--- a/dokuwiki/lib/plugins/include/lang/eo/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/eo/settings.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author Robert Bogenschneider <bogi@uea.org>
+ */
+$lang['noheader']              = 'Ne montri la unuan alineon de inkluditaj paĝoj/sekcioj';
+$lang['firstseconly']          = 'montri nur la unuan sekcion de inkluditaj paĝoj';
+$lang['showtaglogos']          = 'montri bildon por la unua etikedo';
+$lang['showfooter']            = 'montri informojn pri inkludita paĝo sube';
+$lang['showlink']              = 'ligilo al la unua kaplinio de inkludita paĝo';
+$lang['showpermalink']         = 'montri permaligilojn sub inkludita paĝo';
+$lang['showdate']              = 'montri daton sub inkludita paĝo';
+$lang['showmdate']             = 'montri modif-daton sub inkludita paĝo';
+$lang['showuser']              = 'montri uzantonomojn sub inkludita paĝo';
+$lang['showcomments']          = 'montri komentojn sub inkludita paĝo (kromaĵo discussion bezonata)';
+$lang['showlinkbacks']         = 'montri retroligilojn sub inkludita paĝo (kromaĵo linkback bezonata)';
+$lang['showtags']              = 'montri etikedojn sub inkludita paĝo (kromaĵo tag bezonata)';
+$lang['showeditbtn']           = 'montri butonon por modifi';
+$lang['doredirect']            = 'redirekti al la origina paĝo post modifado de la inkludita paĝo';
+$lang['usernamespace']         = 'nomspaco por uzantopaĝoj';
+$lang['doindent']              = 'ŝovi inkluditajn paĝojn relative al la inkludanta paĝo';
+$lang['linkonly']              = 'nur ligi, ne montri la enhavon de la inkludita paĝo';
+$lang['title']                 = 'uzi la unuan titolon de paĝo en ligilo eĉ se useheading estas blokita (koncernas nur linkonly-moduson)';
+$lang['pageexists']            = 'ne montri ligilon, se la paĝo ne ekzistas (koncernas nur linkonly-moduson)';
+$lang['parlink']               = 'meti alineon ĉirkaŭ ligilon (koncernas nur linkonly-moduson)';
+$lang['safeindex']             = 'eviti indeksadon de metadatumoj de nepublikaj inkluditaj paĝoj';
+$lang['order']                 = 'ordigi inkludojn de multaj paĝoj laŭ';
+$lang['order_o_id']            = 'paĝnomo';
+$lang['order_o_title']         = 'titolo';
+$lang['order_o_created']       = 'krea dato';
+$lang['order_o_modified']      = 'modifa dato';
+$lang['order_o_indexmenu']     = 'propra ordo per indexmenu-sintakso';
+$lang['order_o_custom']        = 'propra ordo per include-sintakso';
+$lang['rsort']                 = 'inversigi la ordon de la inkluditaj paĝoj';
+$lang['depth']                 = 'maksimuma profundeco de nomspaco-inkludoj, 0 por senlima profundeco';

--- a/dokuwiki/lib/plugins/include/lang/fr/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/fr/lang.php
@@ -1,12 +1,8 @@
 <?php
+
 /**
- * French language file
- *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     Damien Raude-Morvan <drazzib@drazzib.com>
+ * 
+ * @author Damien Raude-Morvan <drazzib@drazzib.com>
  */
-
-// custom language strings for the plugin
-$lang['readmore'] = 'Lire la suite...';
-
-//Setup VIM: ex: et ts=2 :
+$lang['readmore']              = 'Lire la suite...';

--- a/dokuwiki/lib/plugins/include/lang/fr/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/fr/settings.php
@@ -1,17 +1,42 @@
 <?php
-/**
- * French language file
- *
- * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     Damien Raude-Morvan <drazzib@drazzib.com>
- * @author     Stanislas Reltgen <stanislas@reltgen.net>
- */
- 
-// for the configuration manager
-$lang['firstseconly']    = 'afficher uniquement la premiere section des billets';
-$lang['showlink']        = 'afficher les permaliens sous les billets';
-$lang['showdate']        = 'afficher les dates sous les billets';
-$lang['showuser']        = "afficher le nom de l'utilisateur sous les billets";
-$lang['usernamespace']   = 'espace de nom pour les pages des utilisateurs';
 
-//Setup VIM: ex: et ts=2 :
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author Damien Raude-Morvan <drazzib@drazzib.com>
+ * @author Stanislas Reltgen <stanislas@reltgen.net>
+ * @author bruno <bruno@ninesys.fr>
+ * @author Christian "Na_kai" Sueur <sueur.christian@gmail.com>
+ * @author Fabrice Dejaigher <fabrice@chtiland.com>
+ */
+$lang['noheader']              = 'Ne pas afficher le premier en-tête de pages / sections inclus';
+$lang['firstseconly']          = 'afficher uniquement la première section des billets';
+$lang['showtaglogos']          = 'Afficher l\'image de la première balise';
+$lang['showfooter']            = 'montrer les infos sur la page incluse ci-dessous';
+$lang['showlink']              = 'utiliser le premier en-tête comme lien pour la page incluse';
+$lang['showpermalink']         = 'afficher les permaliens sous la page incluse';
+$lang['showdate']              = 'afficher les dates sous la page incluse';
+$lang['showmdate']             = 'afficher les dates de modification sous la page incluse';
+$lang['showuser']              = 'afficher le nom de l\'utilisateur sous la page incluse';
+$lang['showcomments']          = 'Afficher les commentaires sous la page incluse (Plugin Discussion requis)';
+$lang['showlinkbacks']         = 'Afficher les liens pointants vers la page sous la page incluse (Plugin Linkback requis)';
+$lang['showtags']              = 'Afficher les étiquettes (tags) sous la page incluse (Plugin Tag requis)';
+$lang['showeditbtn']           = 'afficher le bouton d\'édition';
+$lang['doredirect']            = 'rediriger vers la page d\'origine après l\'édition de la page incluse';
+$lang['usernamespace']         = 'espace de nom pour les pages des utilisateurs';
+$lang['doindent']              = 'Indenter les pages incluses par rapport à la page où elles sont incluses';
+$lang['linkonly']              = 'faire un lien vers la page incluse plutôt que d\'afficher son contenu';
+$lang['title']                 = 'utiliser la première en-tête de la page pour le lien même si l\'option \'useheading\' n\'est pas activée (ne concerne que le mode \'lien seul\')';
+$lang['pageexists']            = 'ne pas afficher un lien si la page n\'existe pas (ne concerne que le mode \'lien seul\')';
+$lang['parlink']               = 'mettre le lien dans un paragraphe (ne concerne que le mode lien seul)';
+$lang['safeindex']             = 'empêcher l\'indexation de métadonnées à partir de pages incluses non publiques';
+$lang['order']                 = 'critère de tri des inclusions multi-pages';
+$lang['order_o_id']            = 'Page ID';
+$lang['order_o_title']         = 'titre';
+$lang['order_o_created']       = 'date de création';
+$lang['order_o_modified']      = 'date de modification';
+$lang['order_o_indexmenu']     = 'ordre personnalisé avec la syntaxe de menu d\'index';
+$lang['order_o_custom']        = 'ordre personnalisé avec la syntaxe inclure';
+$lang['rsort']                 = 'inverser l\'ordre de tri des pages incluses';
+$lang['depth']                 = 'profondeur maximale d\'inclusion de l\'espace de nom (namespace), 0 pour une profondeur illimitée';
+$lang['readmore']              = 'Affiche ou pas le lien \'Lire la suite\' dans le cas de l\'affichage de la première section seule';

--- a/dokuwiki/lib/plugins/include/lang/ja/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/ja/lang.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Japanese language file
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Satoshi Sahara <sahara.satoshi@gmail.com>
+ */
+
+// custom language strings for the plugin
+$lang['readmore']   = '→ 続き...';
+
+//Setup VIM: ex: et ts=2 :

--- a/dokuwiki/lib/plugins/include/lang/ja/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/ja/settings.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Japanese language file
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Satoshi Sahara <sahara.satoshi@gmail.com>
+ */
+ 
+// for the configuration manager
+$lang['noheader']      = 'インクルードするページまたはセクションの最初の見だしを表示しない';
+$lang['firstseconly']  = '最初のセクションだけをインクルードする';
+$lang['showtaglogos']  = '（タグが設定されている場合） show image for first tag';
+$lang['showlink']      = 'インクルード部の最初の見だしをインクルード先のページまたはセクションへのリンクとする';
+$lang['showfooter']    = 'インクルード部の下にフッターを表示する';
+$lang['showpermalink'] = 'フッター情報: インクルード先への permalink を表示';
+$lang['showdate']      = 'フッター情報: ページ作成日付(date) を表示';
+$lang['showmdate']     = 'フッター情報: ページ修正日付(modified date) を表示';
+$lang['showuser']      = 'フッター情報: ユーザ名(username) を表示';
+$lang['showcomments']  = 'フッター情報: コメントを表示する (Discussion plugin が必要)';
+$lang['showlinkbacks'] = 'フッター情報: バックリンク(linkback) を表示 (Linkback Plugin が必要)';
+$lang['showtags']      = 'フッター情報: タグ(tag) を表示 (Tag Plugin が必要)';
+$lang['showeditbtn']   = 'インクルード先を編集するボタンを表示';
+$lang['doredirect']    = 'インクルード先の編集後、元のページにリダイレクトして戻る';
+$lang['usernamespace'] = 'ユーザーページの名前空間';
+$lang['doindent']      = 'インクルード部を元ページの当該位置での見出しレベルより1段階下げる';
+$lang['linkonly']      = 'linkonly モードをデフォルトにする： インクルードせず、指定ページまたはセクションへのリンクだけを表示';
+$lang['title']         = '(linkonly モード時)： リンクタイトルに最初の見出しを使う（useheading の指定によらず適用）';
+$lang['pageexists']    = '(linkonly モード時)： インクルードするページが存在しない場合は何も表示しない ';
+$lang['parlink']       = '(linkonly モード時)： リンクを「段落」とする （インラインリストにする場合は無効にしてください）';
+$lang['safeindex']     = 'prevent indexing of metadata from non-public included pages';
+$lang['order']         = '(名前空間インクルード時) ページソートに使う項目';
+$lang['order_o_id']    = 'ページ ID';
+$lang['order_o_title'] = 'タイトル';
+$lang['order_o_created'] = '作成日時';
+$lang['order_o_modified'] = '修正日時';
+$lang['order_o_indexmenu'] = 'indexmenu プラグイン互換のソート方法';
+$lang['order_o_custom'] = 'include プラグイン互換のソート方法';
+$lang['rsort']         = '(名前空間インクルード時) ページソートを逆順にする';
+$lang['depth']         = '(名前空間インクルード時) インクルード対象とする名前空間の最大深さ （0:制限なし）';
+//Setup VIM: ex: et ts=2 :

--- a/dokuwiki/lib/plugins/include/lang/ko/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/ko/lang.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author Myeongjin <aranet100@gmail.com>
+ */
+$lang['readmore']              = '→ 더 읽기...';

--- a/dokuwiki/lib/plugins/include/lang/ko/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/ko/settings.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author Myeongjin <aranet100@gmail.com>
+ */
+$lang['noheader']              = '포함된 문서/문단의 첫 문단 제목을 보이지 않기';
+$lang['firstseconly']          = '포함된 문서의 첫 문단만 보이기';
+$lang['showtaglogos']          = '첫 태그에 대한 그림 보이기';
+$lang['showfooter']            = '아래에 포함된 문서 대한 정보 보이기';
+$lang['showlink']              = '포함된 문서의 첫 문단 제목에 링크';
+$lang['showpermalink']         = '포함된 문서 아래에 고유링크 보이기';
+$lang['showdate']              = '포함된 문서 아래에 날짜 보이기';
+$lang['showmdate']             = '포함된 문서 아래에 수정된 날짜 보이기';
+$lang['showuser']              = '포함된 문서 아래에 사용자 이름 보이기';
+$lang['showcomments']          = '포함된 문서 아래에 덧글 보이기 (Discussion 플러그인 필요)';
+$lang['showlinkbacks']         = '포함된 문서 아래에 링크백 보이기 (Linkback 플러그인 필요)';
+$lang['showtags']              = '포함된 문서 아래에 태그 보이기 (Tag 플러그인 필요)';
+$lang['showeditbtn']           = '편집 버튼 보이기';
+$lang['doredirect']            = '포함된 문서를 편집하고 나서 원래 문서로 넘겨주기';
+$lang['usernamespace']         = '사용자 문서에 대한 이름공간';
+$lang['doindent']              = '원래 문서의 해당 위치에서 포함된 문서를 들여쓰기';
+$lang['linkonly']              = '내용을 보여주는 대신 포함된 문서에만 링크';
+$lang['title']                 = 'useheading이 꺼져 있어도 링크에서 문서의 첫 문단 제목을 사용 (linkonly 모드만 영향을 줍니다)';
+$lang['pageexists']            = '문서가 존재하지 않을 때 링크를 보이지 않기 (linkonly 모드만 영향을 줍니다)';
+$lang['parlink']               = '링크 주위에 문단 넣기 (linkonly 모드만 영향을 줍니다)';
+$lang['safeindex']             = '공개되지 않은 포함된 문서에서 메타데이터의 색인을 방지';
+$lang['order']                 = '여러 문서로 포함의 조건 정렬';
+$lang['order_o_id']            = '문서 ID';
+$lang['order_o_title']         = '제목';
+$lang['order_o_created']       = '만든 날짜';
+$lang['order_o_modified']      = '수정한 날짜';
+$lang['order_o_indexmenu']     = 'indexmenu 문법 사용자 지정 정렬';
+$lang['order_o_custom']        = 'include 문법 사용자 지정 정렬';
+$lang['rsort']                 = '포함된 문서의 정렬 순서를 반대로';
+$lang['depth']                 = '이름공간 포함의 최대 깊이, 제한 없는 깊이는 0';

--- a/dokuwiki/lib/plugins/include/lang/nl/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/nl/lang.php
@@ -1,12 +1,8 @@
 <?php
+
 /**
- * dutch language file
- *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
  * @author     Gijs H. van Gemert <g.v.gemert@inter.nl.net>
  */
-
-// custom language strings for the plugin
-$lang['readmore']   = '→ Lees verder...';
-
-//Setup VIM: ex: et ts=2 :
+$lang['readmore']              = '→ Lees verder...';

--- a/dokuwiki/lib/plugins/include/lang/nl/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/nl/settings.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author Mark Prins <mprins@users.sf.net>
+ */
+$lang['noheader']              = 'toon de eerste kop van de ingesloten pagina/sectie niet';
+$lang['firstseconly']          = 'toon alleen de eerste sectie van de ingesloten pagina\'s';
+$lang['showtaglogos']          = 'toon afbeelding voor het eerste label';
+$lang['showfooter']            = 'toon informatie over de pagina onder de ingesloten pagina';
+$lang['showlink']              = 'link de eerste kop van de ingesloten pagina';
+$lang['showpermalink']         = 'toon permanente link onder de ingesloten pagina';
+$lang['showdate']              = 'toon data onder de ingesloten pagina';
+$lang['showmdate']             = 'toon aanpassingsdatum onder de ingesloten pagina';
+$lang['showuser']              = 'toon gebruikersnamen onder de ingesloten pagina';
+$lang['showcomments']          = 'toon commentaar onder de ingesloten pagina (Discussion plugin vereist)';
+$lang['showlinkbacks']         = 'toon linkbacks onder de ingesloten pagina (Linkback plugin vereist)';
+$lang['showtags']              = 'toon labels onder de ingesloten pagina (Tag plugin vereist)';
+$lang['showeditbtn']           = 'toon aanpassen knop';
+$lang['doredirect']            = 'verwijs naar de originele pagina na aanpassen van de ingesloten pagina';
+$lang['usernamespace']         = 'naamruimte voor gebruikers pagina\'s';
+$lang['doindent']              = 'spring ingesloten pagina\'s in relatief aan de pagina waarin ze ingesloten worden';
+$lang['linkonly']              = 'alleen een link naar de ingesloten pagina opnemen en niet de inhoud';
+$lang['title']                 = 'gebruik de eerste kop als link ook al staat useheading uit (alleen van toepassing op linkonly modus)';
+$lang['pageexists']            = 'toon geen link als de pagina niet bestaat (alleen van toepassing op linkonly modus)';
+$lang['parlink']               = 'plaats een alinea om de link (alleen van toepassing op linkonly modus)';
+$lang['safeindex']             = 'voorkom indexering van metadata van niet-publieke ingesloten pagina\'s';
+$lang['order']                 = 'volgorde criteria van insluitingen bij meerdere pagina\'s';
+$lang['order_o_id']            = 'pagina ID';
+$lang['order_o_title']         = 'titel';
+$lang['order_o_created']       = 'aanmaak datum';
+$lang['order_o_modified']      = 'aanpassingsdatum';
+$lang['order_o_indexmenu']     = 'aangepaste volgorde met indexmenu syntax';
+$lang['order_o_custom']        = 'aangepaste volgorde met include syntax';
+$lang['rsort']                 = 'draai de sorteervolgorde van de ingesloten pagina\'s om';
+$lang['depth']                 = 'maximum diepte van de naamruimte insluitingen, 0 voor onbeperkt';

--- a/dokuwiki/lib/plugins/include/lang/pt/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/pt/lang.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Portuguese language file
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Esther Brunner <wikidesign@gmail.com>
+ * @author     Fernando Ribeiro <pinguim.ribeiro@gmail.com>
+ */
+
+// custom language strings for the plugin
+$lang['readmore']   = '→ Ler mais...';
+
+//Setup VIM: ex: et ts=2 :

--- a/dokuwiki/lib/plugins/include/lang/ru/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/ru/lang.php
@@ -1,13 +1,10 @@
 <?php
+
 /**
- * Russian language file
- *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     Spike <Spike@Foobar2000.Ru>
- * @author     Aleksandr Selivanov <alexgearbox@gmail.com>
+ * 
+ * @author Spike <Spike@Foobar2000.Ru>
+ * @author Aleksandr Selivanov <alexgearbox@gmail.com>
+ * @author Aleksandr Selivanov <alexgearbox@yandex.ru>
  */
-
-// custom language strings for the plugin
-$lang['readmore']   = '→ Читать дальше...';
-
-//Setup VIM: ex: et ts=2 :
+$lang['readmore']              = 'Читать дальше...';

--- a/dokuwiki/lib/plugins/include/lang/ru/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/ru/settings.php
@@ -1,26 +1,29 @@
 <?php
-/**
- * Russian language file
- *
- * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     Spike <Spike@Foobar2000.Ru>
- * @author     Aleksandr Selivanov <alexgearbox@gmail.com>
- */
- 
-// for the configuration manager
-$lang['firstseconly']  = 'Показывать только первую секцию внедряемой страницы';
-$lang['showtaglogos']  = 'Показывать изображение для первого тега';
-$lang['showfooter']    = 'Снизу показывать информацию о&nbsp;внедряемой странице';
-$lang['showlink']      = 'Снизу показывать статичную ссылку на внедряемую страницу';
-$lang['showpermalink'] = 'Снизу показывать пермассылку на&nbsp;внедряемую страницу';
-$lang['showdate']      = 'Снизу показывать дату создания внедряемой страницы';
-$lang['showuser']      = 'Снизу показывать имя пользователя';
-$lang['showcomments']  = 'Показывать комментарии ниже внедряемой страницы (требуется плагин &laquo;Обсуждение&raquo;)';
-$lang['showlinkbacks'] = 'Показывать обратные ссылки ниже внедряемой страницы (требуется плагин &laquo;Обратные ссылки&raquo;)';
-$lang['showtags']      = 'Показывать теги ниже внедряемой страницы (требуется плагин &laquo;Тег&raquo;)';
-$lang['showeditbtn']   = 'Показывать кнопку &laquo;Править&raquo;';
-$lang['doredirect']    = 'Переходить на&nbsp;оригинальную страницу после редактирования внедрённой страницы';
-$lang['usernamespace'] = 'Пространство имён для страниц пользователей';
-$lang['doindent']      = 'Создавать отступ для внедряемой страницы относительно основной страницы';
 
-//Setup VIM: ex: et ts=2 :
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author Spike <Spike@Foobar2000.Ru>
+ * @author Aleksandr Selivanov <alexgearbox@gmail.com>
+ * @author Aleksandr Selivanov <alexgearbox@yandex.ru>
+ */
+$lang['noheader']              = 'Не показывать первый заголовок внедряемых страниц, секций';
+$lang['firstseconly']          = 'Показывать только первую секцию внедряемой страницы';
+$lang['showtaglogos']          = 'Показывать изображение для первого тега';
+$lang['showfooter']            = 'Снизу показывать информацию о внедряемой странице';
+$lang['showlink']              = 'Снизу показывать статичную ссылку на внедряемую страницу';
+$lang['showpermalink']         = 'Снизу показывать пермассылку на внедряемую страницу';
+$lang['showdate']              = 'Снизу показывать дату создания внедряемой страницы';
+$lang['showmdate']             = 'Снизу показывать дату изменения внедряемой страницы';
+$lang['showuser']              = 'Снизу показывать имя пользователя';
+$lang['showcomments']          = 'Показывать комментарии ниже внедряемой страницы (требуется плагин Discussion)';
+$lang['showlinkbacks']         = 'Показывать обратные ссылки ниже внедряемой страницы (требуется плагин Linkback)';
+$lang['showtags']              = 'Показывать теги ниже внедряемой страницы (требуется плагин Tag)';
+$lang['showeditbtn']           = 'Показывать кнопку «Править»';
+$lang['doredirect']            = 'Переходить на оригинальную страницу после редактирования внедрённой страницы';
+$lang['usernamespace']         = 'Пространство имён для страниц пользователей';
+$lang['doindent']              = 'Создавать отступ для внедряемой страницы относительно основной страницы';
+$lang['order_o_id']            = 'ID страницы';
+$lang['order_o_title']         = 'заголовку';
+$lang['order_o_created']       = 'дате создания';
+$lang['order_o_modified']      = 'дате изменения';

--- a/dokuwiki/lib/plugins/include/lang/tr/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/tr/lang.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author İlker R. Kapaç <irifat@gmail.com>
+ */
+$lang['readmore']              = '→ Devamını oku..';

--- a/dokuwiki/lib/plugins/include/lang/tr/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/tr/settings.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author İlker R. Kapaç <irifat@gmail.com>
+ */
+$lang['noheader']              = 'Eklenen sayfaların/bölümlerin ilk başlığını gösterme';
+$lang['firstseconly']          = 'eklenen sayfaların sadece ilk bölümünü göster';
+$lang['showtaglogos']          = 'ilk etiket için resim göster';
+$lang['showfooter']            = 'alt tarafta, eklenen sayfa için bilgi göster';
+$lang['showlink']              = 'eklenen sayfanın ilk başlığını bağlantı haline getir';
+$lang['showpermalink']         = 'eklenen sayfanın altında kalıcı bağlantılar göster';
+$lang['showdate']              = 'eklenen sayfanın altında tarihleri göster';
+$lang['showmdate']             = 'eklenen sayfanın altında değiştirilme tarihlerini göster';
+$lang['showuser']              = 'eklenen sayfanın altında kullanıcı isimlerini göster';
+$lang['showcomments']          = 'eklenen sayfanın altında tartışmaları görüntüle (Bunun için Discussion eklentisi gereklidir)';
+$lang['showlinkbacks']         = 'eklenen sayfanın altında geri bağlantıları göster (Bunun için Linkback eklentisi gereklidir)';
+$lang['showtags']              = 'eklenen sayfanın altında etiketleri göster (Bunun için Tag eklentisi gereklidir)';
+$lang['showeditbtn']           = 'düzenle düğmesini göster';
+$lang['doredirect']            = 'eklenen sayfayı düzenledikten sonra orjinal sayfaya yönlendir';
+$lang['usernamespace']         = 'kullanıcı sayfaları için isimalanı';
+$lang['doindent']              = 'eklenen sayfaları dahil edildikleri sayfaya göre girintili yap';
+$lang['linkonly']              = 'içeriği göstermek yerine, sadece eklenen sayfaya bağlantı göster';
+$lang['title']                 = 'sayfa başlığını kullanma kapalı bile olsa, sayfanın ilk başlığını bağlantıda kullan (yalnızca bağlantı göster seceneği etkinken çalışır)';
+$lang['pageexists']            = 'sayfa mevcut değilse bağlantı gösterme (yalnızca bağlantı göster seceneği etkinken çalışır)';
+$lang['parlink']               = 'bağlantıya bir paragraf ekle  (yalnızca bağlantı göster seceneği etkinken çalışır)';
+$lang['safeindex']             = 'eklenmiş kamuya kapalı (non-public) sayfadan üstverinin (metadata) dizine alınmasına izin verme';
+$lang['order']                 = 'çok sayfalı eklemeler için sıralama ölçütü';
+$lang['order_o_id']            = 'sayfa kimliği (ID)';
+$lang['order_o_title']         = 'başlık';
+$lang['order_o_created']       = 'oluşturma tarihi';
+$lang['order_o_modified']      = 'değiştirilme tarihi';
+$lang['order_o_indexmenu']     = 'indexmenu sözdizimi ile rasgele sıralı';
+$lang['order_o_custom']        = 'include sözdizimi ile rasgele sıralı';
+$lang['rsort']                 = 'eklenen sayfaların sıralamasını ters çevir';
+$lang['depth']                 = 'dahil edilecek en fazla isimalanı derinliği, sınırsız derinlik için 0';

--- a/dokuwiki/lib/plugins/include/lang/zh/lang.php
+++ b/dokuwiki/lib/plugins/include/lang/zh/lang.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author lainme <lainme993@gmail.com>
+ */
+$lang['readmore']              = '→ 阅读更多...';

--- a/dokuwiki/lib/plugins/include/lang/zh/settings.php
+++ b/dokuwiki/lib/plugins/include/lang/zh/settings.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ * @author lainme <lainme993@gmail.com>
+ */
+$lang['noheader']              = '不要显示所包含的页面/章节中的第一个标题';
+$lang['firstseconly']          = '仅显示所包含页面的第一个章节';
+$lang['showtaglogos']          = '对第一个标签显示图片';
+$lang['showfooter']            = '在下方显示所包含页面的信息';
+$lang['showlink']              = '对所包含页面的第一个标题加超链接';
+$lang['showpermalink']         = '在下方显示所包含页面的永久链接';
+$lang['showdate']              = '在下方显示所包含页面的日期';
+$lang['showmdate']             = '在下方显示所包含页面的修改日期';
+$lang['showuser']              = '在下方显示所包含页面的用户名';
+$lang['showcomments']          = '在下方显示所包含页面的评论数';
+$lang['showlinkbacks']         = '在下方显示所包含页面的 linkback';
+$lang['showtags']              = '在下方显示所包含页面的标签';
+$lang['showeditbtn']           = '显示编辑按钮';
+$lang['doredirect']            = '编辑所包含的页面后转向到原始页面';
+$lang['usernamespace']         = '用户页的命名空间';
+$lang['doindent']              = '相对所在页面对包含的页面进行缩进';
+$lang['linkonly']              = '仅显示到所包含页面的链接而不显示内容';
+$lang['title']                 = '即使 useheading 选项关闭也使用页面的第一个标题进行超链接 (仅影响 linkonly 模式)';
+$lang['pageexists']            = '不要显示不存在的页面的链接 (仅影响 linkonly 模式)';
+$lang['order_o_id']            = '页面 ID';
+$lang['order_o_title']         = '标题';
+$lang['order_o_created']       = '创建日期';
+$lang['order_o_modified']      = '修改日期';
+$lang['rsort']                 = '对包含的页面进行反向排序';
+$lang['depth']                 = '包含命名空间的最大深度，0表示不限制';

--- a/dokuwiki/lib/plugins/include/plugin.info.txt
+++ b/dokuwiki/lib/plugins/include/plugin.info.txt
@@ -1,7 +1,7 @@
 base   include
 author Michael Hamann, Gina Häussge, Christopher Smith, Michael Klier, Esther Brunner
-email  plugin-include@content-space.de
-date   2011-01-01
+email  michael@content-space.de
+date   2013-11-25
 name   include plugin
 desc   Functions to include another page in a wiki page
 url    http://dokuwiki.org/plugin:include

--- a/dokuwiki/lib/plugins/include/script.js
+++ b/dokuwiki/lib/plugins/include/script.js
@@ -9,27 +9,14 @@
  * @author Michael Klier <chi@chimeric.de>
  * @author Michael Hamann <michael@content-space.de>
  */
-addInitEvent(function(){
-    var btns = getElementsByClass('btn_incledit',document,'form');
-    for(var i=0; i<btns.length; i++){
-        addEvent(btns[i],'mouseover',function(e){
-            var container_div = this;
-            while (container_div != document && !container_div.className.match(/\bplugin_include_content\b/)) {
-                container_div = container_div.parentNode;
-            }
-
-            if (container_div != document) {
-                container_div.className += ' section_highlight';
-            }
+jQuery(function() {
+    jQuery('.btn_incledit')
+        .mouseover(function () {
+            jQuery(this).closest('.plugin_include_content').addClass('section_highlight');
+        })
+        .mouseout(function () {
+            jQuery('.section_highlight').removeClass('section_highlight');
         });
-
-        addEvent(btns[i],'mouseout',function(e){
-            var secs = getElementsByClass('section_highlight',document,'div');
-            for(var j=0; j<secs.length; j++){
-                secs[j].className = secs[j].className.replace(/ section_highlight/,'');
-            }
-        });
-    }
 });
 
 // vim:ts=4:sw=4:et:

--- a/dokuwiki/lib/plugins/include/style.css
+++ b/dokuwiki/lib/plugins/include/style.css
@@ -1,7 +1,7 @@
-div.dokuwiki div.include div.secedit {
+div.dokuwiki div.plugin_include_content div.secedit {
   float: right;
   margin-left: 1em;
-  margin-top: -18px;
+  margin-top: 0;
 }
 
 div.dokuwiki div.inclmeta {
@@ -10,7 +10,7 @@ div.dokuwiki div.inclmeta {
   color: __text_neu__;
   font-size: 80%;
   line-height: 1.25;
-  margin-top: 0.5em;
+  /*margin-top: 0.5em;*/
   margin-bottom: 2em;
 }
 
@@ -40,4 +40,8 @@ div.dokuwiki div.inclmeta div.tags {
   font-size: 100%;
   float: right;
   clear: none;
+}
+
+div.dokuwiki p.include_readmore {
+  text-align: right;
 }

--- a/dokuwiki/lib/plugins/include/syntax/closelastsecedit.php
+++ b/dokuwiki/lib/plugins/include/syntax/closelastsecedit.php
@@ -9,7 +9,7 @@
 if (!defined('DOKU_PLUGIN'))
     define('DOKU_PLUGIN', DOKU_INC . 'lib/plugins/');
 
-class syntax_plugin_include_close_last_secedit extends DokuWiki_Syntax_Plugin {
+class syntax_plugin_include_closelastsecedit extends DokuWiki_Syntax_Plugin {
 
     function getType() {
         return 'formatting';
@@ -19,16 +19,18 @@ class syntax_plugin_include_close_last_secedit extends DokuWiki_Syntax_Plugin {
         return 50;
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
     /**
      * Finishes the last open section edit
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode == 'xhtml') {
-						$renderer->finishSectionEdit();
+            /** @var Doku_Renderer_xhtml $renderer */
+            list($endpos) = $data;
+            $renderer->finishSectionEdit($endpos);
             return true;
         }
         return false;

--- a/dokuwiki/lib/plugins/include/syntax/editbtn.php
+++ b/dokuwiki/lib/plugins/include/syntax/editbtn.php
@@ -22,7 +22,7 @@ class syntax_plugin_include_editbtn extends DokuWiki_Syntax_Plugin {
         return 50;
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
@@ -31,25 +31,11 @@ class syntax_plugin_include_editbtn extends DokuWiki_Syntax_Plugin {
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function render($mode, &$renderer, $data) {
-        global $lang;
-        list($page, $sect, $sect_title, $redirect_id) = $data;
+    function render($mode, Doku_Renderer $renderer, $data) {
+        list($title) = $data;
         if ($mode == 'xhtml') {
-            $title = ($sect) ? $sect_title : $page;
-            $params = array('do' => 'edit', 
-                             'id' => $page);
-            if ($redirect_id !== false)
-                $params['redirect_id'] = $redirect_id;
-            $xhtml .= '<div class="secedit">' . DOKU_LF;
-            $xhtml .= '<form class="button btn_incledit" method="post" action="' . DOKU_SCRIPT . '"><div class="no">' . DOKU_LF;
-            foreach($params as $key => $val) {
-                $xhtml .= '<input type="hidden" name="'.$key.'" ';
-                $xhtml .= 'value="'.htmlspecialchars($val).'" />';
-            }
-            $xhtml .= '<input type="submit" value="'.htmlspecialchars($lang['btn_secedit']).' (' . $page . ')" class="button" title="'.$title.'"/>' . DOKU_LF;
-            $xhtml .= '</div></form>' . DOKU_LF;
-            $xhtml .= '</div>' . DOKU_LF;
-            $renderer->doc .= $xhtml;
+            $renderer->startSectionEdit(0, 'plugin_include_editbtn', $title);
+            $renderer->finishSectionEdit();
             return true;
         }
         return false;

--- a/dokuwiki/lib/plugins/include/syntax/footer.php
+++ b/dokuwiki/lib/plugins/include/syntax/footer.php
@@ -22,7 +22,7 @@ class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
         return 300;
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
@@ -32,7 +32,7 @@ class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
      * Code heavily copied from the header renderer from inc/parser/xhtml.php, just
      * added an href parameter to the anchor tag linking to the wikilink.
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
 
         list($page, $sect, $sect_title, $flags, $redirect_id, $footer_lvl) = $data;
         
@@ -52,11 +52,11 @@ class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
         if(!$flags['footer']) return '';
 
         $meta  = p_get_metadata($page);
+        $exists = page_exists($page);
         $xhtml = array();
-
         // permalink
         if ($flags['permalink']) {
-            $class = (page_exists($page) ? 'wikilink1' : 'wikilink2');
+            $class = ($exists ? 'wikilink1' : 'wikilink2');
             $url   = ($sect) ? wl($page) . '#' . $sect : wl($page);
             $name  = ($sect) ? $sect_title : $page;
             $title = ($sect) ? $page . '#' . $sect : $page;
@@ -73,7 +73,7 @@ class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
         }
 
         // date
-        if ($flags['date']) {
+        if ($flags['date'] && $exists) {
             $date = $meta['date']['created'];
             if ($date) {
                 $xhtml[] = '<abbr class="published" title="'.strftime('%Y-%m-%dT%H:%M:%SZ', $date).'">'
@@ -81,9 +81,19 @@ class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
                        . '</abbr>';
             }
         }
+        
+        // modified date
+        if ($flags['mdate'] && $exists) {
+            $mdate = $meta['date']['modified'];
+            if ($mdate) {
+                $xhtml[] = '<abbr class="published" title="'.strftime('%Y-%m-%dT%H:%M:%SZ', $mdate).'">'
+                       . strftime($conf['dformat'], $mdate)
+                       . '</abbr>';
+            }
+        }
 
         // author
-        if ($flags['user']) {
+        if ($flags['user'] && $exists) {
             $author   = $meta['creator'];
             if ($author) {
                 $userpage = cleanID($this->getConf('usernamespace').':'.$author);

--- a/dokuwiki/lib/plugins/include/syntax/locallink.php
+++ b/dokuwiki/lib/plugins/include/syntax/locallink.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Include plugin (locallink component)
+ *
+ * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author  Michael Hamann <michael@content-space.de>
+ */
+
+if (!defined('DOKU_INC')) die('must be used inside DokuWiki');
+
+class syntax_plugin_include_locallink extends DokuWiki_Syntax_Plugin {
+
+    function getType() {
+        return 'formatting';
+    }
+
+    function getSort() {
+        return 50;
+    }
+
+    function handle($match, $state, $pos, Doku_Handler $handler) {
+        // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
+    }
+
+    /**
+     * Displays a local link to an included page
+     *
+     * @author Michael Hamann <michael@content-space.de>
+     */
+    function render($mode, Doku_Renderer $renderer, $data) {
+        global $ID;
+        if ($mode == 'xhtml') {
+            /** @var Doku_Renderer_xhtml $renderer */
+            list($hash, $name, $id) = $data;
+            // construct title in the same way it would be done for internal links
+            $default = $renderer->_simpleTitle($id);
+            $name    = $renderer->_getLinkTitle($name, $default, $isImage, $id);
+            $title   = $ID.' ↵';
+            $renderer->doc .= '<a href="#'.$hash.'" title="'.$title.'" class="wikilink1">';
+            $renderer->doc .= $name;
+            $renderer->doc .= '</a>';
+            return true;
+        }
+        return false;
+    }
+}
+// vim:ts=4:sw=4:et:

--- a/dokuwiki/lib/plugins/include/syntax/readmore.php
+++ b/dokuwiki/lib/plugins/include/syntax/readmore.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Include plugin (editbtn header component)
+ *
+ * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author  Michael Hamann <michael@content-space.de>
+ */
+
+class syntax_plugin_include_readmore extends DokuWiki_Syntax_Plugin {
+
+    function getType() {
+        return 'formatting';
+    }
+
+    function getSort() {
+        return 50;
+    }
+
+    function handle($match, $state, $pos, Doku_Handler $handler) {
+        // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
+    }
+
+    function render($mode, Doku_Renderer $renderer, $data) {
+        list($page) = $data;
+
+        if ($mode == 'xhtml') {
+            $renderer->doc .= DOKU_LF.'<p class="include_readmore">'.DOKU_LF;
+        } else {
+            $renderer->p_open();
+        }
+
+        $renderer->internallink($page, $this->getLang('readmore'));
+
+        if ($mode == 'xhtml') {
+            $renderer->doc .= DOKU_LF.'</p>'.DOKU_LF;
+        } else {
+            $renderer->p_close();
+        }
+
+        return true;
+    }
+}
+// vim:ts=4:sw=4:et:

--- a/dokuwiki/lib/plugins/include/syntax/sorttag.php
+++ b/dokuwiki/lib/plugins/include/syntax/sorttag.php
@@ -1,0 +1,62 @@
+<?php
+
+if(!defined('DOKU_INC')) die();
+
+/**
+ * Include plugin sort order tag, idea and parts of the code copied from the indexmenu plugin.
+ *
+ * @license     GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author      Samuele Tognini <samuele@netsons.org>
+ * @author      Michael Hamann <michael@content-space.de>
+ *
+ */
+class syntax_plugin_include_sorttag extends DokuWiki_Syntax_Plugin {
+
+    /**
+     * What kind of syntax are we?
+     */
+    public function getType(){
+        return 'substition';
+    }
+
+    /**
+     * The paragraph type - block, we don't need paragraph tags
+     *
+     * @return string The paragraph type
+     */
+    public function getPType() {
+        return 'block';
+    }
+
+    /**
+     * Where to sort in?
+     */
+    public function getSort(){
+        return 139;
+    }
+
+    /**
+     * Connect pattern to lexer
+     */
+    public function connectTo($mode) {
+        $this->Lexer->addSpecialPattern('{{include_n>.+?}}',$mode,'plugin_include_sorttag');
+    }
+
+    /**
+     * Handle the match
+     */
+    public function handle($match, $state, $pos, Doku_Handler $handler){
+        $match = substr($match,12,-2);
+        return array($match);
+    }
+
+    /**
+     * Render output
+     */
+    public function render($mode, Doku_Renderer $renderer, $data) {
+        if ($mode === 'metadata') {
+            /** @var Doku_Renderer_metadata $renderer */
+            $renderer->meta['include_n'] = $data[0];
+        }
+    }
+}


### PR DESCRIPTION
Hmm, I'm generally not happy to update to a master, but in this case it seems to be appropriate, because the last [official release](https://github.com/dokufreaks/plugin-include/releases) is from 2011-07-19, and in particular, is using a deprecated DokuWiki JS function (addInitEvent). Of course, it would be easy to replace this particular function, but there may be [other relevant bug fixes](https://www.dokuwiki.org/plugin:include#development) (and perhaps security patches) included.

To my knowledge, the include plugin is only used on a few pages (namely todo/php56 and doc/article/php_ide, the latter being already superseeded), so it might be an alternative to get rid of the plugin altogether. Then again, the plugin might be useful for the future.

Anyhow, during testing I didn't notice any problems.