### PR TITLE
Add `baseurl` to prevent host spoofing attacks

### DIFF
--- a/dokuwiki/conf/local.php
+++ b/dokuwiki/conf/local.php
@@ -24,5 +24,6 @@ $conf['useslash'] = 1;
 $conf['send404'] = 1;
 $conf['breadcrumbs'] = 0;
 $conf['youarehere'] = 1;
+$conf['baseurl'] = 'https://wiki.php.net';
 
 // end auto-generated content


### PR DESCRIPTION
If the `baseurl` is not manually set, it'll try to auto-detect the host using the `Host` header in the HTTP request. This allows an attacker to send password reset links to users using a custom domain that the attacker controls.

This is documented here:
https://www.dokuwiki.org/config:baseurl

In some instances, email security and spam filters automatically click said links, giving the attacker the reset token they need in order to steal user accounts without needing the victim to interact with the email at all.

Here's an example:
```shell
curl 'https://wiki.php.net/start?do=resendpwd' \
  -X POST \
  -H 'Host: evil.com' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0' \
  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' \
  -H 'Accept-Language: es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  --data-raw 'sectok=&do=resendpwd&save=1&login=nicoswd'
```

This will send out the following email:
```
Hi nicoswd!

Someone requested a new password for your PHP Wiki login at http://evil.com/

If you did not request a new password then just ignore this email.

To confirm that the request was really sent by you please use the following link.

http://evil.com/start?do=resendpwd&pwauth=xxxxxxxxxxx

--
This mail was generated by DokuWiki at
http://evil.com/
```