### PR TITLE
Fix form action URL in Doodle Plugin to include ID for proper submission

### DIFF
--- a/dokuwiki/lib/plugins/doodle/doodle_template.php
+++ b/dokuwiki/lib/plugins/doodle/doodle_template.php
@@ -13,7 +13,7 @@
 ?>
 
 <!-- Doodle Plugin -->
-<form action="<?php echo wl() ?>" method="post" name="doodle__form" id="<?php echo $template['formId'] ?>" accept-charset="utf-8" >
+<form action="<?php echo wl($ID) ?>#<?php echo $template['formId'] ?>" method="post" name="doodle__form" id="<?php echo $template['formId'] ?>" accept-charset="utf-8" >
 
 <input type="hidden" name="sectok" value="<?php echo getSecurityToken() ?>" />
 <input type="hidden" name="do" value="show" >


### PR DESCRIPTION
If there are multiple voting items in the RFC(e.g. https://wiki.php.net/rfc/deprecations_php_8_5), the first vote will be submitted to `/start`, and subsequent votes will be scrolled to the top of the page.

After modification, the vote will return to the corresponding form anchor.

