### PR TITLE
Render only usernames in doodle_template.php

### DIFF
--- a/dokuwiki/lib/plugins/doodle/doodle_template.php
+++ b/dokuwiki/lib/plugins/doodle/doodle_template.php
@@ -39,8 +39,8 @@
 <?php foreach ($template['doodleData'] as $fullname => $userData) { ?>
     <tr>
         <td class="rightalign">
-          <?php $fullname = '<a href="//people.php.net/' . $fullname.'">' .$fullname. '</a>';?>
-          <?php echo (array_key_exists('editLinks', $userData) ? $userData['editLinks'] : '') . $fullname.$userData['username'] ?>
+          <?php $link = '<a href="https://people.php.net/' . htmlspecialchars($userData['username']) . '">' . htmlspecialchars($userData['username']) . '</a>';?>
+          <?php echo (array_key_exists('editLinks', $userData) ? $userData['editLinks'] : '') . $link; ?>
         </td>
         <?php for ($col = 0; $col < $c; $col++) {
             echo $userData['choice'][$col];

--- a/dokuwiki/lib/plugins/doodle/syntax.php
+++ b/dokuwiki/lib/plugins/doodle/syntax.php
@@ -290,7 +290,7 @@ class syntax_plugin_doodle extends DokuWiki_Syntax_Plugin
             $this->template['count'][$col] = 0;
             foreach ($this->doodle as $fullname => $userData) {
                 if (!empty($userData['username'])) {
-                  $this->template['doodleData']["$fullname"]['username'] = '&nbsp;('.$userData['username'].')';
+                  $this->template['doodleData']["$fullname"]['username'] = $userData['username'];
                 }
                 if (in_array($col, $userData['choices'])) {
                     $timeLoc = strftime($conf['dformat'], $userData['time']);  // localized time of vote
@@ -507,7 +507,7 @@ class syntax_plugin_doodle extends DokuWiki_Syntax_Plugin
         $TR .= '<td class="rightalign">';
         if ($fullname) {
             if ($editMode) $TR .= $this->getLang('edit').':&nbsp;';
-            $TR .= $fullname.'&nbsp;('.$_SERVER['REMOTE_USER'].')';
+            $TR .= $_SERVER['REMOTE_USER'];
             $TR .= '<input type="hidden" name="fullname" value="'.$fullname.'">';
         } else {
             $TR .= '<input type="text" name="fullname" value="">';


### PR DESCRIPTION
For all users with a VCS account (which is the vast majority) the real name matches the username and for the others, the username is the more stable and thus more trustworthy value.